### PR TITLE
Update for latest godot + Option for production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,28 @@ This is Android Adjust plugin for Godot 3.2.2 or higher.
 ![Annotation 2020-07-24 213436](https://user-images.githubusercontent.com/3739222/88424072-9644e300-cdf5-11ea-9a1d-9d282b70550e.png)
 
 ## Basic Example in Godot (GDScript)
+*Recommended: Load the following as a singleton*
 ```
-    const adjust_app_token = "12345.."
-    var adjust
-    if (Engine.has_singleton("GodotAdjust")):
-        print("Adjust was detected")
-        adjust = Engine.get_singleton("GodotAdjust")
-        adjust.init(adjust_app_token)
-    else:
-        print("Adjust was not detected")
+extends Node
+
+const adjust_app_token = "yyzasoa5g2yo"
+const adjust_production = false
+
+var adjust
+func _ready():
+	if (Engine.has_singleton("GodotAdjust")):
+		print("Adjust was detected")
+		adjust = Engine.get_singleton("GodotAdjust")
+		adjust.init(adjust_app_token, adjust_production)
+	else:
+		print("Adjust was not detected")
 ```
 
 ## Api Reference
 
 **Functions:**
 ```
-init(app_token)
+init(app_token, production)
+* app_token - Your adjust app token.
+* production - If true, run adjust in production mode. Else, use sandbox mode.
 ```

--- a/adjust-plugin/src/main/java/com/bashan/godot/adjust/GodotAdjust.java
+++ b/adjust-plugin/src/main/java/com/bashan/godot/adjust/GodotAdjust.java
@@ -21,11 +21,11 @@ public class GodotAdjust extends GodotPlugin {
 
     private static final String TAG = "godot-adjust";
 
-    private Godot activity;
+    private Activity activity;
 
     public GodotAdjust(Godot godot) {
         super(godot);
-        activity = godot;
+        activity = godot.getActivity();
     }
 
     public void init(final String appToken) {
@@ -34,11 +34,13 @@ public class GodotAdjust extends GodotPlugin {
             @Override
             public void run() {
                 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
+                //String environment = AdjustConfig.ENVIRONMENT_PRODUCTION;
 
                 AdjustConfig config = new AdjustConfig(activity, appToken, environment);
                 config.setLogLevel(LogLevel.VERBOSE);
 
                 Adjust.onCreate(config);
+                Adjust.onResume();
 
                 activity.getApplication().registerActivityLifecycleCallbacks(new AdjustLifecycleCallbacks());
 

--- a/adjust-plugin/src/main/java/com/bashan/godot/adjust/GodotAdjust.java
+++ b/adjust-plugin/src/main/java/com/bashan/godot/adjust/GodotAdjust.java
@@ -28,13 +28,12 @@ public class GodotAdjust extends GodotPlugin {
         activity = godot.getActivity();
     }
 
-    public void init(final String appToken) {
+    public void init(final String appToken, final boolean production) {
         Log.i(TAG, "Started initializing GodotAdjust Singleton with App Token: " + appToken);
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
-                //String environment = AdjustConfig.ENVIRONMENT_PRODUCTION;
+                String environment = production ? AdjustConfig.ENVIRONMENT_PRODUCTION : AdjustConfig.ENVIRONMENT_SANDBOX;
 
                 AdjustConfig config = new AdjustConfig(activity, appToken, environment);
                 config.setLogLevel(LogLevel.VERBOSE);


### PR DESCRIPTION
I've updated this to work with Godot 3.5.1
Also:
- Added an option to run in production mode
- Added a call to `Adjust.onResume()` after `Adjust.onCreate()`. Otherwise, a session might not be recorded until an app is closed and reopened (dependent on adjust API version)